### PR TITLE
Frontend: Fix build issues

### DIFF
--- a/Source/Nodes/Archives/BFRESGroupNode.cpp
+++ b/Source/Nodes/Archives/BFRESGroupNode.cpp
@@ -147,10 +147,3 @@ void BFRESGroupNode<GroupType>::SetDictionary(std::shared_ptr<ResourceDictionary
 {
   m_dictionary = value;
 }
-
-// The values aren't meant to be changed.
-template <typename GroupType>
-void BFRESGroupNode<GroupType>::HandleAttributeItemChange(QStandardItem*)
-{
-  return;
-}

--- a/Source/Nodes/Archives/BFRESGroupNode.h
+++ b/Source/Nodes/Archives/BFRESGroupNode.h
@@ -8,26 +8,13 @@
 #include "Formats/Models/FMDL.h"
 #include "Nodes/Node.h"
 
-class BFRESGroupNodeQObject : public Node
-{
-  Q_OBJECT
-public:
-  BFRESGroupNodeQObject(QObject* parent = 0);
-
-signals:
-  void NewDictionary(const ResourceDictionary<FMDL>&);
-  void NewDictionary(const ResourceDictionary<FTEX>&);
-
-protected slots:
-  void HandleAttributeItemChange(QStandardItem* item);
-};
-
 template <typename GroupType>
-class BFRESGroupNode : public BFRESGroupNodeQObject
+class BFRESGroupNode : public Node
 {
 public:
-  BFRESGroupNode(const ResourceDictionary<GroupType>& dictionary = ResourceDictionary<GroupType>(),
-                 QObject* parent = 0);
+  BFRESGroupNode(
+      std::shared_ptr<ResourceDictionary<GroupType>> dictionary = ResourceDictionary<GroupType>(),
+      QObject* parent = 0);
   BFRESGroupNode(const BFRESGroupNode& other);
   BFRESGroupNode& operator=(const BFRESGroupNode& other);
 
@@ -37,10 +24,10 @@ public:
 
   ResultCode LoadAttributeArea();
 
-  void SetDictionary(const ResourceDictionary<GroupType>& value);
+  void SetDictionary(std::shared_ptr<ResourceDictionary<GroupType>> value);
 
 private:
-  ResourceDictionary<GroupType> m_dictionary;
+  std::shared_ptr<ResourceDictionary<GroupType>> m_dictionary;
   // TODO: what's this? owo
   typename ResourceDictionary<GroupType>::Header m_dictionary_header;
 

--- a/Source/Nodes/Node.h
+++ b/Source/Nodes/Node.h
@@ -49,5 +49,5 @@ signals:
 protected slots:
   void HandleFileTreeClick(QModelIndex index);
   void HandleTreeCustomContextMenuRequest(const QPoint& point);
-  virtual void HandleAttributeItemChange(QStandardItem* item) = 0;
+  virtual void HandleAttributeItemChange(QStandardItem*) { return; }
 };


### PR DESCRIPTION
This PR fixes issues with `BFRESGroupNode` that were preventing compilation. Additionally, `BFRESGroupNodeQObject` is now removed. The purpose of `BFRESGroupNodeQObject` was so that `BFRESGroupNode` could have a QObject parent. The issue that made this necessary was that Qt's Metaobject Compiler (`moc`) does not allow templated classes to have the `Q_OBJECT` macro. `BFRESGroupNode` needed the macro in order to implement the slots for when an attribute has changed. However, I have decided that, there's no need for it.

The two attributes of a `BFRESGroupNode` are the size of the group, and the number of nodes. Really, there is no reason to even have this be editable. If a user abritrarily edits these, the BFRES will be screwed anyways.